### PR TITLE
Use a simple boolean for the "Failer" flag to save memory allocations.

### DIFF
--- a/lib/metacoffee/ometa-base.js
+++ b/lib/metacoffee/ometa-base.js
@@ -40,7 +40,7 @@
       (new M).matchAll("123456789", "number")
     */
 
-    var Failer, ListOMInputStream, OMInputStream, OMInputStreamEnd, OMeta, getTag, isImmutable, isSequenceable, makeOMInputStreamProxy, objectThatDelegatesTo, stringDigitValue;
+    var ListOMInputStream, OMInputStream, OMInputStreamEnd, OMeta, getTag, isImmutable, isSequenceable, makeOMInputStreamProxy, objectThatDelegatesTo, stringDigitValue;
     isImmutable = function(x) {
       return x === null || x === void 0 || typeof x === "boolean" || typeof x === "number" || typeof x === "string";
     };
@@ -195,15 +195,6 @@
         }
       });
     };
-    Failer = (function() {
-
-      function Failer() {}
-
-      Failer.prototype.used = false;
-
-      return Failer;
-
-    })();
     OMeta = (function() {
 
       OMeta.prototype.fail = {
@@ -218,20 +209,22 @@
       }
 
       OMeta.prototype._apply = function(rule) {
-        var ans, failer, memoRec, origInput, sentinel;
-        memoRec = this.input.memo[rule];
+        var ans, failer, memo, memoRec, origInput, sentinel;
+        memo = this.input.memo;
+        memoRec = memo[rule];
         if (memoRec === void 0) {
           origInput = this.input;
-          failer = new Failer();
           if (this[rule] == null) {
             throw 'tried to apply undefined rule "' + rule + '"';
           }
-          this.input.memo[rule] = failer;
-          this.input.memo[rule] = memoRec = {
+          memo[rule] = false;
+          memoRec = {
             ans: this[rule].call(this),
             nextInput: this.input
           };
-          if (failer.used) {
+          failer = memo[rule];
+          memo[rule] = memoRec;
+          if (failer === true) {
             sentinel = this.input;
             while (true) {
               try {
@@ -250,8 +243,8 @@
               }
             }
           }
-        } else if (memoRec instanceof Failer) {
-          memoRec.used = true;
+        } else if (typeof memoRec === 'boolean') {
+          memo[rule] = true;
           throw this.fail;
         }
         this.input = memoRec.nextInput;


### PR DESCRIPTION
This changes the Failer from an object to a simple boolean, this means there is no longer a need to allocate/create objects constantly and reduces the overhead of checking for left recursion.
