### PR TITLE
Fix for wrong hex digits parsing

### DIFF
--- a/extras/metacoffee.js
+++ b/extras/metacoffee.js
@@ -2559,14 +2559,14 @@ BSOMetaParser = subclass(BSDentParser, {
     var ch;
     return function () {
       ch = this._apply("anything");
-      return "0123456709abcdef".indexOf(ch.toLowerCase());
+      return "0123456789abcdef".indexOf(ch.toLowerCase());
     }.call(this);
   },
   "hexDigit": function () {
     var x, v;
     return function () {
       x = this._apply("char");
-      v = this.hexValue(x);
+      v = this._applyWithArgs("hexValue", x);
       this._pred(v >= 0);
       return v;
     }.call(this);

--- a/lib/metacoffee/bs-ometa-compiler.js
+++ b/lib/metacoffee/bs-ometa-compiler.js
@@ -100,7 +100,7 @@
         at = this._idxConsumedBy((function() {
           return ch = this._apply("anything")
         }));
-        return '0123456709abcdef'.indexOf(ch.toLowerCase())
+        return '0123456789abcdef'.indexOf(ch.toLowerCase())
       }).call(this)
     },
     "hexDigit": function() {
@@ -109,7 +109,7 @@
         at = this._idxConsumedBy((function() {
           return (function() {
             x = this._apply("char");
-            v = this.hexValue(x);
+            v = this._applyWithArgs("hexValue", x);
             return this._pred(v >= 0)
           }).call(this)
         }));

--- a/src/metacoffee/bs-ometa-compiler.mc
+++ b/src/metacoffee/bs-ometa-compiler.mc
@@ -14,8 +14,8 @@ ometa BSOMetaParser extends BSDentParser
   nameFirst      = '_' | '$' | letter
   bareName       = <nameFirst (nameFirst | digit)*>
   name           = spaces bareName
-  hexValue :ch                                                         -> '0123456709abcdef'.indexOf ch.toLowerCase()
-  hexDigit       = char:x {this.hexValue(x)}:v &{v >= 0}               -> v
+  hexValue :ch                                                         -> '0123456789abcdef'.indexOf ch.toLowerCase()
+  hexDigit       = char:x hexValue(x):v &{v >= 0}                      -> v
   escapedChar    = <'\\' ( 'u' hexDigit hexDigit hexDigit hexDigit
                          | 'x' hexDigit hexDigit
                          | char                                   )>:s -> unescape s


### PR DESCRIPTION
While attempting to use rules like "\u000A" in my experimental grammar I encountered the bug in the metacoffee that caused the hex digits to not get matched but also not fail, resulting in very strange behavior (basically \u000A in my grammar got turned into 000A after compilation with metacoffee).

This is the fix for this bug. 