### PR TITLE
Added character range

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ exactly(what)
 ```
 Compares the next thing in the input with the passed-in argument.
 ```coffee
+range('a', 'z')
+'a'..'z'
+```
+Verifies the next character's ascii code is between the two arguments
+```coffee
 firstAndRest(first, rest)
 seq(what)
 notLast(what)

--- a/lib/metacoffee/bs-ometa-compiler.js
+++ b/lib/metacoffee/bs-ometa-compiler.js
@@ -213,6 +213,62 @@
         return ['App', 'exactly', n]
       }).call(this)
     },
+    "charRange": function() {
+      var a, z;
+      return (function() {
+        at = this._idxConsumedBy((function() {
+          return (function() {
+            (function() {
+              switch (this._apply('anything')) {
+                case "\'":
+                  return (function() {
+                    this._not((function() {
+                      return this._applyWithArgs("exactly", "\'")
+                    }));
+                    a = this._apply("escapedChar");
+                    return this._applyWithArgs("exactly", "\'")
+                  }).call(this);
+                case "\"":
+                  return (function() {
+                    this._not((function() {
+                      return this._applyWithArgs("exactly", "\"")
+                    }));
+                    a = this._apply("escapedChar");
+                    return this._applyWithArgs("exactly", "\"")
+                  }).call(this);
+                default:
+                  throw this.fail
+              }
+            }).call(this);
+            this._applyWithArgs("exactly", ".");
+            this._applyWithArgs("exactly", ".");
+            return (function() {
+              switch (this._apply('anything')) {
+                case "\'":
+                  return (function() {
+                    this._not((function() {
+                      return this._applyWithArgs("exactly", "\'")
+                    }));
+                    z = this._apply("escapedChar");
+                    return this._applyWithArgs("exactly", "\'")
+                  }).call(this);
+                case "\"":
+                  return (function() {
+                    this._not((function() {
+                      return this._applyWithArgs("exactly", "\"")
+                    }));
+                    z = this._apply("escapedChar");
+                    return this._applyWithArgs("exactly", "\"")
+                  }).call(this);
+                default:
+                  throw this.fail
+              }
+            }).call(this)
+          }).call(this)
+        }));
+        return ['App', 'range', programString(a), programString(z)]
+      }).call(this)
+    },
     "keyword": function() {
       var xs;
       return (function() {
@@ -583,6 +639,8 @@
         return (function() {
           this._apply("spaces");
           return this._or((function() {
+            return this._apply("charRange")
+          }), (function() {
             return this._apply("charSequence")
           }), (function() {
             return this._apply("string")

--- a/lib/metacoffee/ometa-base.js
+++ b/lib/metacoffee/ometa-base.js
@@ -572,6 +572,13 @@ class M extends OMeta
       throw this.fail;
     };
 
+    OMeta.prototype.range = function(a, z) {
+      var r;
+      r = this._apply("anything");
+      this._pred((a <= r && r <= z));
+      return r;
+    };
+
     OMeta.prototype["true"] = function() {
       var r;
       r = this._apply("anything");

--- a/src/metacoffee/bs-ometa-compiler.mc
+++ b/src/metacoffee/bs-ometa-compiler.mc
@@ -23,6 +23,11 @@ ometa BSOMetaParser extends BSDentParser
   charSequence   = '"'  ( !'"' escapedChar)*:xs  '"'                   -> ['App', 'token',   programString xs.join '']
   string         = '\'' (!'\'' escapedChar)*:xs '\''                   -> ['App', 'exactly', programString xs.join '']
   number         = <'-'? digit+>:n                                     -> ['App', 'exactly', n]
+  charRange      = ( '\'' (!'\'' escapedChar:a) '\''
+                   | '"'  ( !'"' escapedChar:a)  '"'
+                   ) '.' '.'
+                   ( '\'' (!'\'' escapedChar:z) '\''
+                   | '"'  ( !'"' escapedChar:z)  '"' )                 -> ['App', 'range', programString(a), programString(z)]
   keyword :xs    = token(xs) !letterOrDigit                            -> xs
   args           = '(' listOf('hostExpr', ','):xs ")"                  -> xs
                  | empty                                               -> []
@@ -58,7 +63,7 @@ ometa BSOMetaParser extends BSDentParser
   expr1          = application
                  | ( keyword('undefined') | keyword('nil')
                    | keyword('true')      | keyword('false') ):x       -> ['App', 'exactly', x]
-                 | spaces (charSequence | string | number)
+                 | spaces (charRange | charSequence | string | number)
                  | "["  expr(0):x "]"                                  -> ['Form',      x]
                  | "<"  expr(0):x ">"                                  -> ['ConsBy',    x]
                  | "@<" expr(0):x ">"                                  -> ['IdxConsBy', x]

--- a/src/metacoffee/ometa-base.coffee
+++ b/src/metacoffee/ometa-base.coffee
@@ -380,6 +380,11 @@ module.exports = class OMeta
       return wanted
     throw @fail
 
+  range: (a, z) ->
+    r = @_apply("anything")
+    @_pred(a <= r <= z)
+    r
+
   true: ->
     r = @_apply("anything")
     @_pred(r == true)


### PR DESCRIPTION
Examples:

``` coffee
range('a', 'z')      # matches any character in the char code range equal or between 'a' and 'z'
'a'..'z'             # same as above
'\u0000'..'\u0020'   # matches any character with char code range 0 through 32 (0x20)
```
